### PR TITLE
chore: 유저워킹 타이틀 수정

### DIFF
--- a/project/artist/models.py
+++ b/project/artist/models.py
@@ -10,10 +10,10 @@ class Category(Enum):
 
 
 class Artist(models.Model):
-    category = models.CharField(max_length=10, choices=[(status.value, status.name) for status in Category])
-    artistName = models.CharField(max_length=50)
+    category = models.CharField(max_length=10, choices=[(status.value, status.name) for status in Category], default=Category.기타.value)
+    artistName = models.CharField(max_length=50, null=False)
     members = models.CharField(max_length=200, null=True)
-    artistImage = models.ImageField()
+    artistImage = models.ImageField(null=False)
 
     instagram = models.URLField()
     twitter = models.URLField()

--- a/project/artist/templates/artist/artist_info.html
+++ b/project/artist/templates/artist/artist_info.html
@@ -31,7 +31,7 @@
 <div class="custom-box">
     <div class="artist_info">
         <div class="artist_members"> <strong>멤버</strong> {{ artist.members }}</div>
-        <div class="artist_debuteDate"> <strong>데뷔</strong> {{ artist.debutDate }}</div>
+        <div class="artist_debuteDate"> <strong>데뷔</strong> {{ artist.debutDate|date:"Y년 m월 d일" }}</div>
         <div class="artist_fanName"> <strong>팬덤</strong> {{ artist.fanName }}</div>
         <div class="artist_agency"> <strong>회사</strong> {{ artist.agency }}</div>
         <div class="social_icon">

--- a/project/meeting/templates/html/meeting_create.html
+++ b/project/meeting/templates/html/meeting_create.html
@@ -34,7 +34,7 @@
         <div class="select-wrapper " style="border:none; margin-top:-50px;">
 
         <label for="id_image" class="addImg-Button">사진</label>
-        <input type="file" name="image" id="id_image" required style="display:none;">
+        <input type="file" name="image" id="id_image" style="display:none;" required>
         </div>
         </div>
 

--- a/project/post/models.py
+++ b/project/post/models.py
@@ -18,8 +18,8 @@ class Post(models.Model):
     category = models.CharField(max_length=10, choices=[(status.value, status.name) for status in Category], default=Category.가수.value)
 
     image = models.ImageField(null=True)
-    title = models.CharField(max_length=50)
-    contents = models.TextField(max_length=1000)
+    title = models.CharField(max_length=50, null=False)
+    contents = models.TextField(max_length=1000, null=False)
     regTime = models.DateTimeField(auto_now=True)
 
     def __str__(self):
@@ -28,7 +28,7 @@ class Post(models.Model):
 class Comment(models.Model):
     post = models.ForeignKey(Post, on_delete=models.CASCADE)
     author = models.ForeignKey(User, on_delete=models.CASCADE)
-    contents = models.TextField(max_length=200)
+    contents = models.TextField(max_length=200, null=False)
     regTime = models.DateTimeField(auto_now=True)
 
     def __str__(self):

--- a/project/userWorking/templates/userWorking/userWorking.html
+++ b/project/userWorking/templates/userWorking/userWorking.html
@@ -3,7 +3,7 @@
 {% with artist=artist alerts=alerts %}
 {% block content %}
 <div style="display: flex; align-items: center; justify-content: center; flex-direction: column;">
-    <h1 class="support_form_h1" style="margin-bottom: 20px;">나의 활동 내역</h1>
+    <h1 class="support_form_h1" style="margin-bottom: 20px;">{% if member %}{{ member.userName }}{% else %}{{ request.user.userName }}{% endif %}의 활동 내역</h1>
      
     <div style="display: flex; align-items: center;">
         <img class="use_working_img" src="{{ userWorking.artist.artistImage.url }}">

--- a/project/userWorking/views.py
+++ b/project/userWorking/views.py
@@ -70,6 +70,6 @@ def show_userWorking_guest(request, pk, meetingMember_id):
             userWorking.likeDays = likeDays.days  # 올바른 방법: likeDays.days
             userWorking.save()
 
-            return render(request, 'userWorking/userWorking.html', context={'userWorking':userWorking, 'artist':artist, 'alerts':alerts})
+            return render(request, 'userWorking/userWorking.html', context={'userWorking':userWorking, 'artist':artist, 'alerts':alerts, 'member':user})
 
     return redirect('user:login')


### PR DESCRIPTION
유저워킹 페이지 타이틀이 원래 '나의 활동 내역'으로 고정되어있었는데 모임 신청자의 신청자보기 버튼 클릭 시의 상황에서도 나의 활동 내역이라고 뜨기 때문에 '해당 유저의 이름 + 활동 내역'으로 타이틀을 수정하였다.