### PR TITLE
fix: 알림 생성시간 등록 버그 수정

### DIFF
--- a/project/alert/models.py
+++ b/project/alert/models.py
@@ -8,7 +8,7 @@ class Alert(models.Model):
     artist = models.ForeignKey(Artist, on_delete=models.CASCADE)
     message = models.CharField(max_length=300, null=True)
     openChatURL = models.URLField(null=True)
-    regTime = models.DateTimeField(auto_now=True)
+    regTime = models.DateTimeField()
     is_read = models.BooleanField(default=False)
 
     def __str__(self):

--- a/project/post/views.py
+++ b/project/post/views.py
@@ -1,3 +1,5 @@
+from django.utils import timezone
+
 from alert.models import Alert
 from django.shortcuts import render, redirect, get_object_or_404
 
@@ -67,7 +69,8 @@ def create_post(request, artist_pk):
         Alert.objects.create(
             user=user,
             artist=artist,
-            message=F'<{title}> 게시글이 등록되었습니다!'
+            message=F'<{title}> 게시글이 등록되었습니다!',
+            regTime=timezone.now()
         )
 
         # 이용행보 수정

--- a/project/templates/header.html
+++ b/project/templates/header.html
@@ -32,12 +32,6 @@
 
 </div>
 
-
-{% if unread_alerts %}
-<!-- 안 읽은 알림이 있을 때의 코드 작성해주시면 됩니다. -->
-{% endif %}
-
-
 <div class="notification-popup" id="notification-popup">
   <div class="notification-content">
 
@@ -50,7 +44,6 @@
       <div class="alert-openchat">{{ alert.openChatURL }}</div>
       {% endif %}
       <div class="alert-time">{{ alert.regTime|date:"Y.m.d H:i" }}</div>
-      {{ alert.is_read }}
     </div>
     {% endfor %}
   </div>


### PR DESCRIPTION
알림 생성 시간이 알림을 조회한 시각으로 뜨는 버그가 있었다.
알림 모델의 등록 시간을 regTime=models.DateTimeField(auto_now=True) 자동으로 현재 시간이 들어가도록 작성했었는데 왜인지 모르겠으나 조회할 때의 시각으로 떠서 default 값을 제거하고 알림 생성 시 regTime=timezone.now()로 수정하였더니 제대로 등록되었다. 